### PR TITLE
Fix bug where FSTF-TYPE for AAV2 recording is set to ADV.

### DIFF
--- a/OccuRec.Core/OccuRec.Core.cpp
+++ b/OccuRec.Core/OccuRec.Core.cpp
@@ -2460,7 +2460,7 @@ HRESULT StartRecordingInternal_AAV2(LPCTSTR szFileName)
 
 	Check(AdvVer2::AdvVer2_AddFileTag("RECORDER-SOFTWARE", "OccuRec"));
 	Check(AdvVer2::AdvVer2_AddFileTag("RECORDER-SOFTWARE-VERSION", occuRecVersion));
-	Check(AdvVer2::AdvVer2_AddFileTag("FSTF-TYPE", "ADV"));
+	Check(AdvVer2::AdvVer2_AddFileTag("FSTF-TYPE", "AAV"));
 	Check(AdvVer2::AdvVer2_AddFileTag("ADV-VERSION", "2"));
 	Check(AdvVer2::AdvVer2_AddFileTag("AAV-VERSION", "2"));
 	Check(AdvVer2::AdvVer2_AddFileTag("OS-VERSION", OS_VERSION));


### PR DESCRIPTION
Fix bug where FSTF-TYPE for AAV2 recording is set to ADV instead of AAV. This causes problems later in Tangra.